### PR TITLE
Adding --city flag

### DIFF
--- a/cmd/company.go
+++ b/cmd/company.go
@@ -30,6 +30,7 @@ var (
 	includeNumbers        int
 	includePostal         int
 	includeAll            bool
+	includeCity           string
 )
 
 var companyCmd = &cobra.Command{
@@ -55,6 +56,7 @@ func init() {
 	companyCmd.Flags().StringVarP(&includeMask, "mask", "m", "", "Apply a custom mask to the passwords")
 	companyCmd.Flags().IntVar(&includeNumbers, "numbers", 0, "Include numbers to the passwords")
 	companyCmd.Flags().IntVarP(&includePostal, "postal", "p", 0, "Include postal code to the passwords")
+	companyCmd.Flags().StringVar(&includeCity, "city", "", "Include city name to the passwords")
 	companyCmd.Flags().BoolVarP(&includeAll, "all", "a", false, "Include all variations")
 }
 
@@ -168,6 +170,10 @@ func generateCompanyPasslist(name string) []string {
 
 	if includePostal != 0 {
 		wordlist = append(wordlist, generate.WithPostal(baseWordlist, includePostal)...)
+	}
+
+	if includeCity != "" {
+		wordlist = append(wordlist, generate.WithCity(baseWordlist, includeCity)...)
 	}
 
 	wordlist = append(wordlist, baseWordlist...)

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -218,6 +218,7 @@ func WithPostal(wordlist []string, includePostal int) []string {
 	return result
 }
 
+// WithCity appends the city name to each word in the wordlist
 func WithCity(wordlist []string, includeCity string) []string {
 	var result []string
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -217,3 +217,13 @@ func WithPostal(wordlist []string, includePostal int) []string {
 	}
 	return result
 }
+
+func WithCity(wordlist []string, includeCity string) []string {
+	var result []string
+
+	for _, word := range wordlist {
+		result = append(wordlist, word+includeCity)
+	}
+
+	return result
+}


### PR DESCRIPTION
Hey ! Here's my PR for issue #6 
**Description**

Adding a feature to city's name to each password of our wordlist. This is responding to the issue https://github.com/GoToolSharing/passfinder/issues/6

**Fixes # (issue)**
Type of change

    [+] New feature
    [+] This change requires a documentation update

**How Has This Been Tested?**

Locally, with no version/dependencies update at all.

    [+] Test A : Only with --city flag
    cmd : passfinder company -n passfinder --city Paris

output :
```

passfinder
passfinderParis

```
**Checklist:**

    [+] My code follows the style guidelines of this project
    [+] I have performed a self-review of my code
    [+] I have commented my code, particularly in hard-to-understand areas
    [+] My changes generate no new warnings

Hope this help !